### PR TITLE
Reduce lag when panning zoomed-out galactic map

### DIFF
--- a/Site/code/anacreon.js
+++ b/Site/code/anacreon.js
@@ -62,7 +62,7 @@ $Anacreon.debugPrices = function ()
 	var i;
 	var traderSovereign;
 
-	for (i = 0; i < $Anacreon.sovereignList.length; i++)
+	for (i in $Anacreon.sovereignList)
 		{
 		var sovereign = $Anacreon.sovereignList[i];
 		if (sovereign != null
@@ -563,7 +563,7 @@ $Anacreon.processUpdate = function (updateList)
 	//	Clear all caches (we need to do this because sovereigns do not get 
 	//	updated every cycle).
 
-	for (i = 0; i < $Anacreon.sovereignList.length; i++)
+	for (i in $Anacreon.sovereignList)
 		if ($Anacreon.sovereignList[i])
 			$Anacreon.sovereignList[i].clearCaches();
 	
@@ -780,7 +780,7 @@ $Anacreon.initSession = function (onInitialized)
 
 			//	Get sovereigns
 				
-			$Anacreon.sovereignList = [];
+			$Anacreon.sovereignList = {};
 			for (i = 0; i < data.sovereigns.length; i++)
 				{
 				var sovereign = data.sovereigns[i];

--- a/Site/code/galacticmap.js
+++ b/Site/code/galacticmap.js
@@ -565,7 +565,7 @@ $GalacticMap.onDraw = function (mapMetrics)
 		{
 		var options = { clipToMap:!snapshot };
 
-		for (i = 0; i < $Anacreon.sovereignList.length; i++)
+		for (i in $Anacreon.sovereignList)
 			{
 			var sovereign = $Anacreon.sovereignList[i];
 			if (sovereign)

--- a/Site/code/trantor.js
+++ b/Site/code/trantor.js
@@ -1290,6 +1290,8 @@ function onAnimate ()
 	    	    })
     		});
 		}
+
+	requestAnimationFrame(onAnimate)
 	}
 		
 function onKeypress (e)
@@ -1522,7 +1524,7 @@ $(document).ready(function () {
 			{
 			$Map.invalidate();
 			$(window).resize(function () { $Map.invalidate(); });
-			setInterval(onAnimate, 1000 / FRAMES_PER_SECOND);
+			onAnimate();
 			return;
 			}
 
@@ -1588,6 +1590,6 @@ $(document).ready(function () {
 
 		//	Start animation
 			
-		setInterval(onAnimate, 1000 / FRAMES_PER_SECOND);
+		onAnimate()
 		});
 	});


### PR DESCRIPTION
**The cause of the lag**

To draw empire names under capital worlds when the map is zoomed out, `$GalacticMap.onDraw` iterates through a list through all  sovereigns playing the game. However, despite only having ~250 non-null elements, the list is ~3.9 million items long because the array is indexed by the sovereign ID. 

**The solution**

By using an object instead of an array, the time spent drawing sovereign names is reduced.